### PR TITLE
observability/kube-prometheus: allow deploy with argo

### DIFF
--- a/observability/kube-prometheus/apps.Makefile
+++ b/observability/kube-prometheus/apps.Makefile
@@ -3,7 +3,6 @@ all: gen
 gen-output:
 	mkdir -p gen-output
 
-
 .PHONY: gen
 gen: clean gen-output
 	kubectl kustomize . | kubectl slice -o gen-output --skip-non-k8s --template "{{.metadata.name}}.{{.metadata.namespace}}.{{.kind | lower}}.yaml"

--- a/observability/kube-prometheus/gen-output/prometheusagents.monitoring.coreos.com..customresourcedefinition.yaml
+++ b/observability/kube-prometheus/gen-output/prometheusagents.monitoring.coreos.com..customresourcedefinition.yaml
@@ -2,8 +2,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    argocd.argoproj.io/sync-options: ServerSideApply=true
     controller-gen.kubebuilder.io/version: v0.11.1
-  creationTimestamp: null
   name: prometheusagents.monitoring.coreos.com
 spec:
   group: monitoring.coreos.com

--- a/observability/kube-prometheus/gen-output/prometheuses.monitoring.coreos.com..customresourcedefinition.yaml
+++ b/observability/kube-prometheus/gen-output/prometheuses.monitoring.coreos.com..customresourcedefinition.yaml
@@ -2,8 +2,8 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
+    argocd.argoproj.io/sync-options: ServerSideApply=true
     controller-gen.kubebuilder.io/version: v0.11.1
-  creationTimestamp: null
   name: prometheuses.monitoring.coreos.com
 spec:
   group: monitoring.coreos.com

--- a/observability/kube-prometheus/kustomization.yaml
+++ b/observability/kube-prometheus/kustomization.yaml
@@ -2,6 +2,8 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 patches:
+- path: manifests/patches/0prometheusCustomResourceDefinition.yaml
+- path: manifests/patches/0prometheusagentCustomResourceDefinition.yaml
 - path: manifests/patches/prometheus-ClusterRole.yaml
 - path: manifests/patches/prometheus-prometheus.yaml
 - path: manifests/patches/alertmanager-secret.secret.yaml

--- a/observability/kube-prometheus/manifests/patches/0prometheusCustomResourceDefinition.yaml
+++ b/observability/kube-prometheus/manifests/patches/0prometheusCustomResourceDefinition.yaml
@@ -1,0 +1,6 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: ServerSideApply=true
+  name: prometheuses.monitoring.coreos.com

--- a/observability/kube-prometheus/manifests/patches/0prometheusagentCustomResourceDefinition.yaml
+++ b/observability/kube-prometheus/manifests/patches/0prometheusagentCustomResourceDefinition.yaml
@@ -1,0 +1,6 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: ServerSideApply=true
+  name: prometheusagents.monitoring.coreos.com


### PR DESCRIPTION
Currently, ArgoCD fails to deploy the Prometheus and PrometheusAgent
CRDs because it complains that:
```
"prometheusagents.monitoring.coreos.com" is invalid: metadata.annotations: Too long: must have at most 262144 bytes (retried 5 times).
```

To fix this, we can patch the resoruces as described in
https://github.com/prometheus-community/helm-charts/issues/3435.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>
