### PR TITLE
pyrra: refactor update.sh

### DIFF
--- a/observability/pyrra/update.sh
+++ b/observability/pyrra/update.sh
@@ -3,4 +3,19 @@
 rm -rf manifests/upstream
 mkdir -p manifests/upstream
 (cd manifests/upstream && curl -fsSO https://raw.githubusercontent.com/pyrra-dev/pyrra/main/examples/kubernetes/manifests-webhook/setup/pyrra-slo-CustomResourceDefinition.yaml)
-(cd manifests/upstream && printf "apiDeployment\napiService\napiServiceAccount\napiServiceMonitor\ncertificate\nissuer\nkubernetesClusterRole\nkubernetesClusterRoleBinding\nkubernetesDeployment\nkubernetesService\nkubernetesServiceAccount\nkubernetesServiceMonitor\nwebhook" | xargs -I {} curl -fsSO https://raw.githubusercontent.com/pyrra-dev/pyrra/main/examples/kubernetes/manifests-webhook/pyrra-{}.yaml)
+(cd manifests/upstream && head -c -1 <<EOF | parallel -I {} curl -fsSO https://raw.githubusercontent.com/pyrra-dev/pyrra/main/examples/kubernetes/manifests-webhook/pyrra-{}.yaml
+apiDeployment
+apiService
+apiServiceAccount
+apiServiceMonitor
+certificate
+issuer
+kubernetesClusterRole
+kubernetesClusterRoleBinding
+kubernetesDeployment
+kubernetesService
+kubernetesServiceAccount
+kubernetesServiceMonitor
+webhook
+EOF
+)


### PR DESCRIPTION
This commit refactors the update.sh script to be easier to read and thus
maintain. The funcitonality is exactly the same, only that rather than
pipe a multiline string to xargs we pipe a heredoc.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>
