### PR TITLE
dex: remove deprecated serviceAccount field

### DIFF
--- a/auth_security/dex/gen-output/dex.dex.deployment.yaml
+++ b/auth_security/dex/gen-output/dex.dex.deployment.yaml
@@ -58,7 +58,6 @@ spec:
       restartPolicy: Always
       schedulerName: default-scheduler
       securityContext: {}
-      serviceAccount: dex
       serviceAccountName: dex
       terminationGracePeriodSeconds: 30
       volumes:

--- a/auth_security/dex/manifests/dex.deploy.yaml
+++ b/auth_security/dex/manifests/dex.deploy.yaml
@@ -45,7 +45,6 @@ spec:
       restartPolicy: Always
       schedulerName: default-scheduler
       securityContext: {}
-      serviceAccount: dex
       serviceAccountName: dex
       terminationGracePeriodSeconds: 30
       volumes:


### PR DESCRIPTION
This commit removes the deprecated serviceAccount field from the
deployment, since it is no longer used and in fact is causing odd
interactions with generated downstream dexs with suffixes.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>
