### PR TITLE
kube-thanos: bump to fix races in compactor

### DIFF
--- a/observability/kube-thanos/gen-output/thanos-compact.thanos.statefulset.yaml
+++ b/observability/kube-thanos/gen-output/thanos-compact.thanos.statefulset.yaml
@@ -76,7 +76,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        image: quay.io/thanos/thanos:v0.32.2
+        image: quay.io/thanos/thanos:v0.32.5
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 4

--- a/observability/kube-thanos/gen-output/thanos-query-frontend.thanos.deployment.yaml
+++ b/observability/kube-thanos/gen-output/thanos-query-frontend.thanos.deployment.yaml
@@ -85,7 +85,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        image: quay.io/thanos/thanos:v0.32.2
+        image: quay.io/thanos/thanos:v0.32.5
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 4

--- a/observability/kube-thanos/gen-output/thanos-query.thanos.deployment.yaml
+++ b/observability/kube-thanos/gen-output/thanos-query.thanos.deployment.yaml
@@ -70,7 +70,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        image: quay.io/thanos/thanos:v0.32.2
+        image: quay.io/thanos/thanos:v0.32.5
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 4

--- a/observability/kube-thanos/gen-output/thanos-store.thanos.statefulset.yaml
+++ b/observability/kube-thanos/gen-output/thanos-store.thanos.statefulset.yaml
@@ -103,7 +103,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        image: quay.io/thanos/thanos:v0.32.2
+        image: quay.io/thanos/thanos:v0.32.5
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 8

--- a/observability/kube-thanos/kustomization.yaml
+++ b/observability/kube-thanos/kustomization.yaml
@@ -44,4 +44,4 @@ patches:
 
 images:
   - name: quay.io/thanos/thanos
-    newTag: v0.32.2
+    newTag: v0.32.5


### PR DESCRIPTION
This commit bumps kube-thanos to fix data races in the object storage
library used by Thanos that would cause the compactor to error out and
restart.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>
