### PR TITLE
Pyrra: Fix validating webhook

### DIFF
--- a/observability/pyrra/kustomization.yaml
+++ b/observability/pyrra/kustomization.yaml
@@ -3,7 +3,6 @@ kind: Kustomization
 namespace: monitoring
 
 commonLabels:
-  app.kubernetes.io/component: monitoring
   app.kubernetes.io/part-of: pyrra
 
 resources:


### PR DESCRIPTION
The common label `part-of` is used by the kubernetesDeployment (which is the web server for the validating webhooks). The value is `kubernetes` there and the service selector uses it. Now we overwrite the label in the kustomization file and end up selecting the apiDeployment and kubernetesDeployemnt as endpoints for the kubernetesService. This breaks every other `kubectl apply` of a pyrra CRD.